### PR TITLE
Move setPlayerName from Find to App.

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -1,10 +1,10 @@
 import './App.css';
 import React, { Component } from 'react'
 import Find from './Find'
-import List from './List'
 import CardFront from './CardFront'
-import CardBack from './CardBack';
 import { getAllCubsPlayers, online } from './Utility';
+import { Route, Switch } from 'react-router-dom';
+import favoritePlayer from './SinglePlayerData.json'
 
 
 class App extends Component {
@@ -14,9 +14,11 @@ class App extends Component {
       allPlayers: [],
       activePlayers: []
     }
+    this.setPlayersName = this.setPlayersName.bind(this)
+
   }
 
-  // to turn on/off the API call, change const 'online' in Utility
+  // to turn on/off the API call, toggle 'online' const in Utility
   componentDidMount() {
     if (online) {
       getAllCubsPlayers()
@@ -27,20 +29,31 @@ class App extends Component {
       this.getActivePlayers(allPlayers)
     }
   }
-
+  
   getActivePlayers(players) {
     const activePlayers = players.filter(player => player.Status === 'Active')
     this.setState({ activePlayers: activePlayers })
+  }
+
+  setPlayersName() {
+    this.state.activePlayers.map(player => {
+      const fullName = `${player.LastName}, ${player.FirstName}`
+      player.name = fullName
+      return fullName
+    })
   }
 
   render() {
     return (
       <div className="app">
         <header className="header">WHO'S THAT CUB?</header>
-        <Find players={this.state.activePlayers}/>
-        <CardFront />
-        <CardBack />
-        <List />
+        <Find players={this.state.activePlayers} setPlayersName={this.setPlayersName}/>
+        <Switch>
+          <Route exact path="/" render={() => <CardFront playerData={favoritePlayer} />} /> 
+          <Route path="/:{playerName}" /> if :playerName, render cardfront of that player
+          <Route path="/:{playerName}/back" /> :playerName/back, render cardback of that player
+          <Route path="/*" /> same as "/"
+        </Switch>
       </div>
     )
   }

--- a/src/CardFront.js
+++ b/src/CardFront.js
@@ -7,7 +7,7 @@ class CardFront extends Component {
     }
 
     render() {
-        if(this.props.playerData) {
+        // console.log(this.props)
             return (
                 <div>
                     <p>
@@ -22,10 +22,8 @@ class CardFront extends Component {
                     <img src={this.props.playerData.PhotoUrl} alt="the player"></img>
                 </div>
             )
-        } else {
-            return null
-        }
+        } 
     }
-}
+
 
 export default CardFront

--- a/src/Find.js
+++ b/src/Find.js
@@ -8,7 +8,6 @@ class Find extends Component {
     constructor() {
         super()
         this.state = {
-            playerName: '',
             playerData: {}
         }
     }
@@ -33,9 +32,12 @@ class Find extends Component {
     }
     
     render() {
-        const opts = this.props.players.map(player => {
-            const fullName = `${player.LastName}, ${player.FirstName}`
+        // move the "get player's name" function to App, pass the returned value down
+
+        const opts = this.props.players.map((player, index) => {
+            this.props.setPlayersName()
             const playerID = `${player.PlayerID}`
+            const fullName = this.props.players[index].name
             return (
                 <option value={fullName} key={playerID} id={player.PlayerID}>{fullName}</option>
             )
@@ -52,7 +54,7 @@ class Find extends Component {
                     </select>
                     <button onClick={this.handleClick}>show this player</button>
                 </form>
-                <CardFront playerName={this.state.playerName} playerData={this.state.playerData}/>
+                {this.state.playerName && <CardFront playerName={this.state.playerName} playerData={this.state.playerData}/>}
             </div>
         )
     }

--- a/src/Utility.js
+++ b/src/Utility.js
@@ -1,5 +1,4 @@
 import allPlayers from './WholeTeamData.json'
-
 export const online = false
 
 export function getAllCubsPlayers() {


### PR DESCRIPTION
## Is this PR a fix/feature/test/other?
Feature
## What does this PR do?
Now that `setPlayerName` is bound to App, I have access to each of the players' full names (instead of `player.FirstName` and `player.LastName`) everywhere I want to pass it. Initial Routes are also set up. I moved the function because I needed the data in App for routing.
## Where should the reviewer start?
`App.js` lines 17, 38-56, `Find.js` lines 35+
## How is this tested?
npm start - the app should still load and the dropdown list should still populate
## Applicable Tickets?
#13 