### PR TITLE
Give up on showing the action shot since not all the players have one.

### DIFF
--- a/src/CardBack.css
+++ b/src/CardBack.css
@@ -25,9 +25,9 @@
 .card-back-player-name {
     z-index: 2;
     position: absolute;
-    color: #ffffff;
+    color: #0E3386;
     font-size: 1.5em;
-    -webkit-text-stroke: .5px #cc3433;
+    -webkit-text-stroke: .5px #ffffff;
 }
 
 .card-back-action-photo {

--- a/src/CardBack.js
+++ b/src/CardBack.js
@@ -6,9 +6,7 @@ import headerPhoto from './action-default-photo.jpeg'
 class CardBack extends Component {
     constructor() {
         super()
-        this.state = {
-            headerPhoto: './action-default-photo.jpeg'
-        }
+        this.state = {}
     }
 
     componentDidMount() {

--- a/src/CardBack.js
+++ b/src/CardBack.js
@@ -1,11 +1,14 @@
 import React, { Component } from 'react'
 import { Link } from 'react-router-dom'
 import './CardBack.css'
+import headerPhoto from './action-default-photo.jpeg'
 
 class CardBack extends Component {
     constructor() {
         super()
-        this.state = {}
+        this.state = {
+            headerPhoto: './action-default-photo.jpeg'
+        }
     }
 
     componentDidMount() {
@@ -76,15 +79,11 @@ class CardBack extends Component {
         }
     }
 
-    getActionPhoto() {
-        return `https://securea.mlb.com/images/players/action_shots/${this.props.chosenPlayer.MLBAMID}.jpg`
-    }
-
     render() {
         return (
             <Link to='/' className='card-back'>
                 <div className="card-back-header">
-                    <img className="card-back-action-photo" src={this.getActionPhoto()} alt='player in action'/>
+                    <img className="card-back-action-photo" src={headerPhoto} alt='baseballs'/>
                     <h3 className="card-back-player-name">{this.getName()}</h3>
                 </div>
                 <div className="card-back-stats-block">

--- a/src/Utility.js
+++ b/src/Utility.js
@@ -9,5 +9,3 @@ export function getAllCubsPlayers() {
         return allPlayers
     }
 }
-
-// ping action photo in a fetch for a status and if it's 404, then show either wrigley or the baseballs


### PR DESCRIPTION
## Is this PR a fix/feature/test/other?
Other
## What does this PR do?
I wanted to grab the players' 'action shot' like I got their portraits, but they don't all have one.
## Where should the reviewer start?
`CardBack.js` 4 and 86
## How is this tested?
All player card backs should have a header photo of baseballs.
## Applicable Tickets?
