### PR TITLE
Feature/image loading

### DIFF
--- a/src/CardFront.css
+++ b/src/CardFront.css
@@ -66,6 +66,7 @@
     border-radius: 50%;
     position: relative;
     top: 50px;
+    z-index: 0;
 }
 
 @keyframes squish {

--- a/src/CardFront.css
+++ b/src/CardFront.css
@@ -41,7 +41,11 @@
 
 .player-picture-box {
     height: 280px;
-    width: auto;
+    width: 187px;
+    display: flex;
+    flex-direction: column;
+    justify-content: center;
+    align-items: center;
     margin: auto;
     border: 4px solid white;
     border-radius: 15px;
@@ -56,6 +60,25 @@
     z-index: 0;
 }
 
+.squish {
+    animation: 1s infinite alternate squish;
+    background-color: #ffffff;
+    border-radius: 50%;
+    position: relative;
+    top: 50px;
+}
+
+@keyframes squish {
+    from {
+        width: 50px;
+        height: 50px;
+    }
+
+    to {
+        width: 150px;
+        height: 150px;
+    }
+}
 .player-position {
     border-radius: 50%;
     position: absolute;

--- a/src/CardFront.js
+++ b/src/CardFront.js
@@ -24,6 +24,7 @@ class CardFront extends Component {
                 onClick={() => this.props.showFrontOrBack('back')}>
                 <h1 className='card-title'>CUBS</h1>
                 <div className='player-picture-box'>
+                    <div className='squish'></div>
                     <img className='player-picture' 
                         src={`https://securea.mlb.com/mlb/images/players/head_shot/${this.setPictureID()}.jpg`} 
                         alt="the player"></img>


### PR DESCRIPTION
## Is this PR a fix/feature/test/other?
Feature
## What does this PR do?
Adds animated loading image for when player picture hasn't shown up yet. This is instead of putting the images in state.
## Where should the reviewer start?
`CardFront.css` 63-82 and `CardFront.js` 27
## How is this tested?
npm start, localhost:3000 - If you comment out `CardFront.js` lines 28-30 so the player's picture doesn't load, you can see the animation.
## Applicable Tickets?
#19 