### PR TITLE
Show Javy if nothing is in local storage.

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -88,7 +88,11 @@ class App extends Component {
               chosenPlayer={this.state.chosenPlayer} 
               showFrontOrBack={this.showFrontOrBack} 
             /> } />
-          <Route path="/*" render={() => <div className='error'><p>That player was not found.</p><p>Please use the search to find a current Cubs player.</p></div>}/> 
+          <Route path="/*" render={() => 
+            <div className='error'>
+              <p>That player was not found.</p>
+              <p>Please use the search to find a current Cubs player.</p>
+            </div>}/>
         </Switch>
         <button 
           className="make-favorite-button" 

--- a/src/Utility.js
+++ b/src/Utility.js
@@ -4,7 +4,7 @@ export const online = false
 
 export function getAllCubsPlayers() {
     if (online) {
-        return fetch('httpasdfs://api.sportsdata.io/v3/mlb/scores/json/Players/CHC?key=b37a9e7224fa4a63900203ee59666bc2')
+        return fetch('https://api.sportsdata.io/v3/mlb/scores/json/Players/CHC?key=b37a9e7224fa4a63900203ee59666bc2')
         .then(response => {
             if (response.status >= 400 && 500 >= response.status) {
                 throw new Error("User Error")
@@ -23,8 +23,14 @@ export function saveToLocalStorage(data) {
     localStorage.setItem('favoritePlayer', JSON.stringify(data))
 }
 
+// If there's nothing in localStorage, return Javy
+// because he should be your favorite anyway.
+
 export function getFromLocalStorage() {
-    saveToLocalStorage(javy)
-    return JSON.parse(localStorage.getItem('favoritePlayer'))
+    const storedPlayer = JSON.parse(localStorage.getItem('favoritePlayer'))
+    if(!storedPlayer) {
+        return javy
+    } else {
+        return storedPlayer
+    }
 }
-// This puts a player (a good one) into local storage for the first time a user opens the app


### PR DESCRIPTION
## Is this PR a fix/feature/test/other?
Fix
## What does this PR do?
It was over-writing the favorite player on a refresh, so now if there's nothing in localStorage, you see Javy's card, but you can change your favorite player and it will save/show properly.
## Where should the reviewer start?
`Utility.js` 26+
## How is this tested?
npm start, localhost:3000
In the console > application, clear localStorage
Refresh the page, see Javy's card
Choose a different favorite
Refresh the page, see your new favorite
## Applicable Tickets?
#55 